### PR TITLE
[STABILITY] - Remove Hack Fix in Vote Timeout Trigger - Type Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Types and traits for the HotShot consesus module"
 edition = "2021"
 name = "hotshot-types"
 readme = "../README.md"
-version = "1.0.0"
+version = "0.1.4"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Types and traits for the HotShot consesus module"
 edition = "2021"
 name = "hotshot-types"
 readme = "../README.md"
-version = "0.1.0"
+version = "1.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -4,7 +4,9 @@
 //! `HotShot`'s version of a block, and proposals, messages upon which to reach the consensus.
 
 use crate::{
-    simple_certificate::{QuorumCertificate, TimeoutCertificate, UpgradeCertificate},
+    simple_certificate::{
+        QuorumCertificate, TimeoutCertificate, UpgradeCertificate, ViewSyncFinalizeCertificate2,
+    },
     simple_vote::UpgradeProposalData,
     traits::{
         block_contents::{
@@ -187,6 +189,10 @@ pub struct QuorumProposal<TYPES: NodeType> {
 
     /// Possible upgrade certificate, which the leader may optionally attach.
     pub upgrade_certificate: Option<UpgradeCertificate<TYPES>>,
+
+    /// Possible view sync certificate. Only present if the justify_qc and timeout_cert are not
+    /// present.
+    pub view_sync_certificate: Option<ViewSyncFinalizeCertificate2<TYPES>>,
 
     /// the propser id
     pub proposer_id: TYPES::SignatureKey,


### PR DESCRIPTION
Type update for: https://github.com/EspressoSystems/HotShot/pull/2739
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR: 
- Adds support for the `ViewSyncFinalizeCertificate2Recv` event in the consensus algorithm.
- Adds the implementation of the view sync certificate in consensus. This implementation initiates a proposal when the event is received.
- Adds support for checking the validity of the cert (if it exists) within the voting logic and failing to vote if the certificate has any invalid properties.
- Tests that a proposal is indeed sent when such an event is received.

### This PR does not: 
- Does not explicitly check the vote failure case where the `is_valid_cert` function on a cert fails.

### Key places to review: 
- All logic for the new handler body. 
    - Specifically, this code acts as though it received a timeout certificate, and follows a similar flow to that in `QCFormed`.
- All tests in the `consensus_task` file.
    - These tests cover the happy path case where the event is captured and the proposal is sent, and when the event is captured, but the node is not able to propose and votes instead. It also validates that the node will _not_ propose when the cert is invalid.

### How to test this PR:
cargo test -p hotshot-testing --test consensus_task

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
