### PR TITLE
[EASY] Recipient Rield of DataRequest

### DIFF
--- a/src/traits/network.rs
+++ b/src/traits/network.rs
@@ -229,8 +229,6 @@ pub struct ResponseChannel<M: NetworkMsg>(pub oneshot::Sender<M>);
 #[derive(Serialize, Deserialize, Derivative, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(bound(deserialize = ""))]
 pub struct DataRequest<TYPES: NodeType> {
-    /// Hotshot key of who to send the request to
-    pub recipient: TYPES::SignatureKey,
     /// Request
     pub request: RequestKind<TYPES>,
     /// View this message is for


### PR DESCRIPTION
This was already in: https://github.com/EspressoSystems/HotShot/pull/2698.  The field is not used on this new type.  