### PR TITLE
Add workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,30 @@
+name: Run Cargo audit
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+  schedule:
+    - cron: '0 0 * * 1' # Run on Mondays
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/main' && github.run_number) || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Audit dependencies
+        run: cargo audit

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,122 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/main' && github.run_number) || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        just_variants:
+          - async-std
+          - tokio
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        name: Enable Rust caching
+        with:
+          shared-key: ""
+          prefix-key: ${{ matrix.just_variants }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install just
+        run: |
+          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
+          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
+          sudo cp just /usr/bin/just
+
+      - name: Run tests
+        run: |
+          just ${{ matrix.just_variants }} test-ci
+        timeout-minutes: 60
+        env:
+          RUST_BACKTRACE: full
+
+  build:
+    strategy:
+      matrix:
+        just_variants:
+          - async-std
+          - tokio
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        name: Enable Rust caching
+        with:
+          shared-key: ""
+          prefix-key: ${{ matrix.just_variants }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install just
+        run: |
+          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
+          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
+          sudo cp just /usr/bin/just
+
+      - name: Build all crates in workspace
+        run: just ${{ matrix.just_variants }} build
+
+  build-hotshot:
+    strategy:
+      matrix:
+        just_variants:
+          - async-std
+          - tokio
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    container: ghcr.io/espressosystems/devops-rust:stable
+    steps:
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        name: Enable Rust caching
+        with:
+          shared-key: ""
+          prefix-key: arm-${{ matrix.just_variants }}
+
+      - name: Install just
+        run: |
+          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
+          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
+          sudo cp just /usr/bin/just
+
+      # Attempt to build HotShot with the current branch of hotshot-types.
+      #
+      # Note: it is expected that changes may frequently break HotShot. 
+      # This is intended to be purely informational and should not run on main. 
+      # The goal is just to ensure that authors are aware if a merge would break HotShot.
+      - name: Build HotShot
+        run: |
+          git clone https://github.com/EspressoSystems/HotShot
+          cd HotShot
+          echo '\n[patch."https://github.com/EspressoSystems/hotshot-types"]\nhotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", rev = "${{ github.sha }}" }' >> Cargo.toml
+          just ${{ matrix.just_variants }} build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,6 +94,11 @@ jobs:
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y capnproto
+
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust caching
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,11 +75,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
-      - name: Install just
-        run: |
-          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
-          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
-          sudo cp just /usr/bin/just
+      - uses: extractions/setup-just@v1
+        name: Install Just
 
       - name: Build all crates in workspace
         run: just ${{ matrix.just_variants }} build
@@ -103,11 +100,8 @@ jobs:
           shared-key: ""
           prefix-key: arm-${{ matrix.just_variants }}
 
-      - name: Install just
-        run: |
-          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
-          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
-          sudo cp just /usr/bin/just
+      - uses: extractions/setup-just@v1
+        name: Install Just
 
       # Attempt to build HotShot with the current branch of hotshot-types.
       #

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -112,5 +112,5 @@ jobs:
         run: |
           git clone https://github.com/EspressoSystems/HotShot
           cd HotShot
-          echo '\n[patch."https://github.com/EspressoSystems/hotshot-types"]\nhotshot-types = { git = "https://github.com/EspressoSystems//hotshot-types", rev = "${{ github.sha }}" }' >> Cargo.toml
+          echo '\n[patch."https://github.com/EspressoSystems/hotshot-types"]\nhotshot-types = { git = "https://github.com/EspressoSystems//hotshot-types", rev = "${{ github.event.pull_request.head.sha }}" }' >> Cargo.toml
           just ${{ matrix.just_variants }} build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,7 +89,6 @@ jobs:
           - tokio
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
-    container: ghcr.io/espressosystems/devops-rust:stable
     steps:
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -112,5 +112,5 @@ jobs:
         run: |
           git clone https://github.com/EspressoSystems/HotShot
           cd HotShot
-          echo '\n[patch."https://github.com/EspressoSystems/hotshot-types"]\nhotshot-types = { git = "https://github.com/EspressoSystems/hotshot-types", rev = "${{ github.sha }}" }' >> Cargo.toml
+          echo '\n[patch."https://github.com/EspressoSystems/hotshot-types"]\nhotshot-types = { git = "https://github.com/EspressoSystems//hotshot-types", rev = "${{ github.sha }}" }' >> Cargo.toml
           just ${{ matrix.just_variants }} build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,5 +116,6 @@ jobs:
         run: |
           git clone https://github.com/EspressoSystems/HotShot
           cd HotShot
-          echo '\n[patch."https://github.com/EspressoSystems/hotshot-types"]\nhotshot-types = { git = "https://github.com/EspressoSystems//hotshot-types", rev = "${{ github.event.pull_request.head.sha }}" }' >> Cargo.toml
+          echo '[patch."https://github.com/EspressoSystems/hotshot-types"]' >> Cargo.toml
+          echo 'hotshot-types = { git = "https://github.com/EspressoSystems//hotshot-types", rev = "${{ github.event.pull_request.head.sha }}" }' >> Cargo.toml
           just ${{ matrix.just_variants }} build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,50 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.ref == 'refs/heads/main' && github.run_number) || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    strategy:
+      matrix:
+        just_variants:
+          - async-std
+          - tokio
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+
+      - run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        name: Enable Rust caching
+        with:
+          shared-key: ""
+          prefix-key: ${{ matrix.just_variants }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install Just
+        run: |
+          wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
+          tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
+          sudo cp just /usr/bin/just
+
+      - name: Lint
+        run: |
+          just ${{ matrix.just_variants }} lint

--- a/justfile
+++ b/justfile
@@ -39,6 +39,10 @@ test *ARGS:
   echo Testing {{ARGS}}
   cargo test --verbose --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1 --nocapture --skip crypto_test
 
+test-ci *ARGS:
+  echo Testing {{ARGS}}
+  RUST_LOG=debug cargo test --verbose --lib --bins --tests --benches --workspace --no-fail-fast {{ARGS}} -- --test-threads=1
+
 check:
   echo Checking
   cargo check --workspace --bins --tests --examples

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,7 +8,7 @@ use crate::data::{QuorumProposal, UpgradeProposal};
 use crate::simple_certificate::{
     DACertificate, ViewSyncCommitCertificate2, ViewSyncFinalizeCertificate2,
     ViewSyncPreCommitCertificate2,
-};
+;
 use crate::simple_vote::{
     DAVote, TimeoutVote, UpgradeVote, ViewSyncCommitVote, ViewSyncFinalizeVote,
     ViewSyncPreCommitVote,

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,7 +8,7 @@ use crate::data::{QuorumProposal, UpgradeProposal};
 use crate::simple_certificate::{
     DACertificate, ViewSyncCommitCertificate2, ViewSyncFinalizeCertificate2,
     ViewSyncPreCommitCertificate2,
-;
+};
 use crate::simple_vote::{
     DAVote, TimeoutVote, UpgradeVote, ViewSyncCommitVote, ViewSyncFinalizeVote,
     ViewSyncPreCommitVote,


### PR DESCRIPTION
Adds workflows to audit, lint, build and test `hotshot-types` on `main` and on pull requests.

Pull requests will also trigger an additional workflow to build HotShot with the new branch. This is only meant to be informative: it is expected that pull requests will often break HotShot, but it should be helpful to know that this is going to happen. This job also does not run on `main` for this reason -- HotShot should point to a tag anyway, and we likely don't expect HotShot to build with the most recent version of `main`.
