### PR TITLE
Add arbitrary messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,13 @@ name = "hotshot-types"
 readme = "../README.md"
 version = "0.1.7"
 
+[features]
+arbitrary-messages = []
+gpu-vid = [
+    "jf-primitives/gpu-vid",
+]
+
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -61,11 +68,6 @@ dyn-clone = { git = "https://github.com/dtolnay/dyn-clone", tag = "1.0.17" }
 
 [dev-dependencies]
 serde_json = { version = "1.0.114" }
-
-[features]
-gpu-vid = [
-    "jf-primitives/gpu-vid",
-]
 
 [target.'cfg(all(async_executor_impl = "async-std"))'.dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/src/message.rs
+++ b/src/message.rs
@@ -84,7 +84,9 @@ pub enum MessagePurpose {
     /// VID disperse, like [`Proposal`].
     VidDisperse,
     /// Message with an upgrade proposal.
-    Upgrade,
+    UpgradeProposal,
+    /// Message with an upgrade vote
+    UpgradeVote,
 
     #[cfg(feature = "arbitrary-messages")]
     /// Arbitrary messages with raw bytes. Mostly intended to be used in testing.

--- a/src/message.rs
+++ b/src/message.rs
@@ -302,8 +302,8 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                     MessagePurpose::ViewSyncCertificate
                 }
 
-                GeneralConsensusMessage::UpgradeProposal(_)
-                | GeneralConsensusMessage::UpgradeVote(_) => MessagePurpose::Upgrade,
+                GeneralConsensusMessage::UpgradeProposal(_) => MessagePurpose::UpgradeProposal,
+                GeneralConsensusMessage::UpgradeVote(_) => MessagePurpose::UpgradeVote,
             },
             SequencingMessage::Committee(committee_message) => match committee_message {
                 CommitteeConsensusMessage::DAProposal(_) => MessagePurpose::Proposal,

--- a/src/message.rs
+++ b/src/message.rs
@@ -218,9 +218,8 @@ pub enum SequencingMessage<TYPES: NodeType> {
 #[serde(bound(deserialize = "", serialize = ""))]
 /// Arbitrary message data. Mostly intended to be used in testing.
 pub struct ArbitraryData<TYPES: NodeType> {
-  /// View number this message originated in.
-  pub view_number: TYPES::Time,
-
+    /// View number this message originated in.
+    pub view_number: TYPES::Time,
 }
 
 impl<TYPES: NodeType> SequencingMessage<TYPES> {
@@ -277,7 +276,7 @@ impl<TYPES: NodeType> SequencingMessage<TYPES> {
                 }
             }
             #[cfg(feature = "arbitrary-messages")]
-            SequencingMessage::Arbitrary(data) => data.view_number
+            SequencingMessage::Arbitrary(data) => data.view_number,
         }
     }
 

--- a/src/traits/network.rs
+++ b/src/traits/network.rs
@@ -66,6 +66,9 @@ pub enum WebServerNetworkError {
     EndpointError,
     /// Client disconnected
     ClientDisconnected,
+    #[cfg(feature = "arbitrary-messages")]
+    /// Attempted to post a raw message to the web server
+    ArbitraryMessageError,
 }
 
 /// the type of transmission

--- a/src/traits/network.rs
+++ b/src/traits/network.rs
@@ -217,6 +217,7 @@ impl<K: SignatureKey> ConsensusIntentEvent<K> {
             | ConsensusIntentEvent::CancelPollForTransactions(view_number)
             | ConsensusIntentEvent::PollFutureLeader(view_number, _) => *view_number,
             ConsensusIntentEvent::PollForLatestProposal
+            | ConsensusIntentEvent::PollForLatestUpgrade
             | ConsensusIntentEvent::PollForLatestViewSyncCertificate => 1,
         }
     }

--- a/src/traits/network.rs
+++ b/src/traits/network.rs
@@ -203,6 +203,8 @@ impl<K: SignatureKey> ConsensusIntentEvent<K> {
         match &self {
             ConsensusIntentEvent::PollForVotes(view_number)
             | ConsensusIntentEvent::PollForProposal(view_number)
+            | ConsensusIntentEvent::PollForUpgradeVotes(view_number)
+            | ConsensusIntentEvent::PollForUpgradeProposal(view_number)
             | ConsensusIntentEvent::PollForDAC(view_number)
             | ConsensusIntentEvent::PollForViewSyncVotes(view_number)
             | ConsensusIntentEvent::CancelPollForViewSyncVotes(view_number)
@@ -219,7 +221,6 @@ impl<K: SignatureKey> ConsensusIntentEvent<K> {
             | ConsensusIntentEvent::CancelPollForTransactions(view_number)
             | ConsensusIntentEvent::PollFutureLeader(view_number, _) => *view_number,
             ConsensusIntentEvent::PollForLatestProposal
-            | ConsensusIntentEvent::PollForLatestUpgrade
             | ConsensusIntentEvent::PollForLatestViewSyncCertificate => 1,
         }
     }

--- a/src/traits/network.rs
+++ b/src/traits/network.rs
@@ -162,6 +162,8 @@ pub enum ConsensusIntentEvent<K: SignatureKey> {
     PollForLatestProposal,
     /// Poll for the most recent view sync proposal the webserver has
     PollForLatestViewSyncCertificate,
+    /// Poll for the most recent view sync proposal the webserver has
+    PollForLatestUpgrade,
     /// Poll for a DAC for a particular view
     PollForDAC(u64),
     /// Poll for view sync votes starting at a particular view

--- a/src/traits/network.rs
+++ b/src/traits/network.rs
@@ -154,16 +154,18 @@ pub enum NetworkError {
 pub enum ConsensusIntentEvent<K: SignatureKey> {
     /// Poll for votes for a particular view
     PollForVotes(u64),
+    /// Poll for upgrade votes for a particular view
+    PollForUpgradeVotes(u64),
     /// Poll for a proposal for a particular view
     PollForProposal(u64),
+    /// Poll for an upgrade proposal for a particular view
+    PollForUpgradeProposal(u64),
     /// Poll for VID disperse data for a particular view
     PollForVIDDisperse(u64),
     /// Poll for the most recent [quorum/da] proposal the webserver has
     PollForLatestProposal,
     /// Poll for the most recent view sync proposal the webserver has
     PollForLatestViewSyncCertificate,
-    /// Poll for the most recent view sync proposal the webserver has
-    PollForLatestUpgrade,
     /// Poll for a DAC for a particular view
     PollForDAC(u64),
     /// Poll for view sync votes starting at a particular view


### PR DESCRIPTION
Adds support for a new `SequencingMessage` variant, gated behind a feature flag.

Largely intended to be used for testing upgradability, but I've tried to make it somewhat flexible to allow for other uses (if any come up).
