### PR TITLE
Fix patch not being used in workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -118,4 +118,5 @@ jobs:
           cd HotShot
           echo '[patch."https://github.com/EspressoSystems/hotshot-types"]' >> Cargo.toml
           echo 'hotshot-types = { git = "https://github.com/EspressoSystems//hotshot-types", rev = "${{ github.event.pull_request.head.sha }}" }' >> Cargo.toml
+          cargo update hotshot-types
           just ${{ matrix.just_variants }} build


### PR DESCRIPTION
Patching `Cargo.toml` in `HotShot` does nothing since `Cargo.lock` is also committed. Fixed by updating `Cargo.lock` in the workflow.
